### PR TITLE
Relax Security when visiting H2 Console

### DIFF
--- a/src/main/java/com/revature/chronicle/security/SecurityConfig.java
+++ b/src/main/java/com/revature/chronicle/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.revature.chronicle.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -27,6 +28,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	 */
 	public SecurityConfig(CorsConfigurationProperties corsConfigurationProperties) {
 		this.corsConfigurationProperties = corsConfigurationProperties;
+	}
+
+	@Override
+	public void configure(WebSecurity web) throws Exception {
+		web
+		  .ignoring()
+			.antMatchers("/h2-console/**");
 	}
 
 	/**


### PR DESCRIPTION
Not fit for a production configuration, but is a fitting solution in a development environment. A further improvement would be to annotate this `SecurityConfig` class with `@Profile("dev")` so that we only expose H2 Console access while the Spring Profile `dev` is active, while creating `ProdSecurityConfig` class, having the same content as previous, but annotated with `@Profile("prod")`.

* Added the overloaded `configure(WebSecurity web)` method to `SecurityConfig`, which ignores security constraints when accessing the H2 console.